### PR TITLE
Fix obscure tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,8 @@ before_script:
       export PATH="$dest/bin:$PATH"
     }
   - setup_zsh $_ZSH_VERSION
+  # Show loaded ZSH modules
+  - "zsh -c 'echo Loaded ZSH Modules: ${(k@)modules}'"
   # Show the git version being used to test.
   - "git --version"
   # Show the mercurial version being used to test.

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -351,8 +351,8 @@ function __p9k_prepare_prompts() {
   local LC_ALL="" LC_CTYPE="en_US.UTF-8" # Set the right locale to protect special characters
 
   if [[ "$P9K_PROMPT_ON_NEWLINE" == true ]]; then
-    PROMPT='${__P9K_ICONS[MULTILINE_FIRST_PROMPT_PREFIX]}%f%b%k$(__p9k_build_left_prompt)
-${__P9K_ICONS[MULTILINE_LAST_PROMPT_PREFIX]}'
+    __p9k_unsafe_PROMPT="${__P9K_ICONS[MULTILINE_FIRST_PROMPT_PREFIX]}%f%b%k$(__p9k_build_left_prompt)
+${__P9K_ICONS[MULTILINE_LAST_PROMPT_PREFIX]}"
     if [[ "$P9K_RPROMPT_ON_NEWLINE" != true ]]; then
       # The right prompt should be on the same line as the first line of the left
       # prompt. To do so, there is just a quite ugly workaround: Before zsh draws
@@ -366,14 +366,19 @@ ${__P9K_ICONS[MULTILINE_LAST_PROMPT_PREFIX]}'
       RPROMPT_SUFFIX=''
     fi
   else
-    PROMPT='%f%b%k$(__p9k_build_left_prompt)'
+    __p9k_unsafe_PROMPT="%f%b%k$(__p9k_build_left_prompt)"
     RPROMPT_PREFIX=''
     RPROMPT_SUFFIX=''
   fi
 
   if [[ "$P9K_DISABLE_RPROMPT" != true ]]; then
-    RPROMPT="$RPROMPT_PREFIX"'%f%b%k$(__p9k_build_right_prompt)%{$reset_color%}'"$RPROMPT_SUFFIX"
+    __p9k_unsafe_RPROMPT="${RPROMPT_PREFIX}%f%b%k$(__p9k_build_right_prompt)%{${reset_color}%}${RPROMPT_SUFFIX}"
+    RPROMPT='$__p9k_unsafe_RPROMPT'
   fi
+
+  # Allow iTerm integration to work
+  [[ ${ITERM_SHELL_INTEGRATION_INSTALLED} == "Yes" ]] \
+    && __p9k_unsafe_PROMPT="%{$(iterm2_prompt_mark)%}$__p9k_unsafe_PROMPT"
 
 local NEWLINE='
 '
@@ -381,11 +386,15 @@ local NEWLINE='
   if [[ $P9K_PROMPT_ADD_NEWLINE == true ]]; then
     NEWLINES=""
     repeat ${P9K_PROMPT_ADD_NEWLINE_COUNT:-1} { NEWLINES+=${NEWLINE} }
-    PROMPT="$NEWLINES$PROMPT"
+    __p9k_unsafe_PROMPT="$NEWLINES$__p9k_unsafe_PROMPT"
   fi
 
-  # Allow iTerm integration to work
-  [[ ${ITERM_SHELL_INTEGRATION_INSTALLED} == "Yes" ]] && PROMPT="%{$(iterm2_prompt_mark)%}$PROMPT"
+  # By evaluating $__p9k_unsafe_PROMPT here in __p9k_prepare_prompts we avoid
+  # the evaluation of $PROMPT being interrupted.
+  # For security $PROMPT is never set directly. This way the prompt render is
+  # forced to evaluate the variable and the contents of $__p9k_unsafe_PROMPT
+  # are never executed. The same applies to $RPROMPT.
+  PROMPT='$__p9k_unsafe_PROMPT'
 }
 
 p9k::set_default P9K_IGNORE_TERM_COLORS false

--- a/segments/background_jobs.p9k
+++ b/segments/background_jobs.p9k
@@ -25,6 +25,8 @@ __p9k_background_jobs() {
   jobs_suspended=${(M)#${jobstates%%:*}:#suspended}
 }
 
+# Load parameter module which makes $jobstates available.
+autoload -Uz zsh/parameter
 # initialize hooks
 autoload -Uz add-zsh-hook
 add-zsh-hook precmd __p9k_background_jobs

--- a/test/core/color_overriding.spec
+++ b/test/core/color_overriding.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 }

--- a/test/core/joining_segments.spec
+++ b/test/core/joining_segments.spec
@@ -7,12 +7,13 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 }
 
 function testLeftNormalSegmentsShouldNotBeJoined() {
-  local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3 custom_world4_joined custom_world5 custom_world6)
   local P9K_CUSTOM_WORLD1="echo world1"
@@ -27,7 +28,6 @@ function testLeftNormalSegmentsShouldNotBeJoined() {
 
 function testLeftJoinedSegments() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo world2"
@@ -36,7 +36,6 @@ function testLeftJoinedSegments() {
 }
 
 function testLeftTransitiveJoinedSegments() {
-  local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined custom_world3_joined)
   local P9K_CUSTOM_WORLD1="echo world1"
@@ -47,7 +46,6 @@ function testLeftTransitiveJoinedSegments() {
 }
 
 function testLeftTransitiveJoiningWithConditionalJoinedSegment() {
-  local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2_joined custom_world3_joined custom_world4_joined)
   local P9K_CUSTOM_WORLD1="echo world1"
@@ -60,7 +58,6 @@ function testLeftTransitiveJoiningWithConditionalJoinedSegment() {
 
 function testLeftPromotingSegmentWithConditionalPredecessor() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
-  local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined)
   local P9K_CUSTOM_WORLD1="echo world1"
   local P9K_CUSTOM_WORLD2="echo " # Print nothing to simulate unmet conditions
@@ -70,7 +67,6 @@ function testLeftPromotingSegmentWithConditionalPredecessor() {
 }
 
 function testLeftPromotingSegmentWithJoinedConditionalPredecessor() {
-  local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined custom_world4_joined)
   local P9K_CUSTOM_WORLD1="echo world1"
@@ -82,7 +78,6 @@ function testLeftPromotingSegmentWithJoinedConditionalPredecessor() {
 }
 
 function testLeftPromotingSegmentWithDeepJoinedConditionalPredecessor() {
-  local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(custom_world1 custom_world2 custom_world3_joined custom_world4_joined custom_world5_joined custom_world6_joined)
   local P9K_CUSTOM_WORLD1="echo world1"
@@ -96,7 +91,6 @@ function testLeftPromotingSegmentWithDeepJoinedConditionalPredecessor() {
 }
 
 function testLeftJoiningBuiltinSegmentWorks() {
-  local -a P9K_LEFT_PROMPT_ELEMENTS
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(php_version php_version_joined)
   alias php="echo PHP 1.2.3 "

--- a/test/core/prompt.spec
+++ b/test/core/prompt.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 }

--- a/test/core/visual_identifier.spec
+++ b/test/core/visual_identifier.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source functions/*

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source functions/*

--- a/test/powerlevel9k.spec
+++ b/test/powerlevel9k.spec
@@ -31,6 +31,7 @@ function testJoinedSegments() {
 function testTransitiveJoinedSegments() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   local P9K_LEFT_PROMPT_ELEMENTS=(dir root_indicator_joined dir_joined)
+  source segments/root_indicator.p9k
   cd /tmp
 
   assertEquals "%K{004} %F{000}/tmp %F{000}/tmp %k%F{004}%f " "$(__p9k_build_left_prompt)"
@@ -128,8 +129,9 @@ function testNewlineOnRpromptCanBeDisabled() {
   local P9K_RIGHT_PROMPT_ELEMENTS=(custom_rworld)
 
   __p9k_prepare_prompts
+  nl=$'\n'
   #             ╭─[39m[0m[49m[107m [30mworld [49m[97m[39m  ╰─ [1A[39m[0m[49m[97m[107m[30m rworld [30m [00m[1B
-  assertEquals '╭─[39m[0m[49m[107m [30mworld [49m[97m[39m  ╰─ [1A[39m[0m[49m[97m[107m[30m rworld [30m [00m[1B' "$(print -P ${PROMPT}${RPROMPT})"
+  assertEquals "╭─[39m[0m[49m[107m [30mworld [49m[97m[39m ${nl}╰─ [1A[39m[0m[49m[97m[107m[30m rworld [30m [00m[1B" "$(print -P ${PROMPT}${RPROMPT})"
 
 }
 

--- a/test/segments/anaconda.spec
+++ b/test/segments/anaconda.spec
@@ -14,6 +14,8 @@ function testAnacondaSegmentPrintsNothingIfNoAnacondaPathIsSet() {
   local P9K_CUSTOM_WORLD='echo world'
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(anaconda custom_world)
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
 
   # Load Powerlevel9k
   source segments/anaconda.p9k

--- a/test/segments/aws_eb_env.spec
+++ b/test/segments/aws_eb_env.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   source powerlevel9k.zsh-theme
 }
 

--- a/test/segments/background_jobs.spec
+++ b/test/segments/background_jobs.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   source powerlevel9k.zsh-theme
 }
 

--- a/test/segments/battery.spec
+++ b/test/segments/battery.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source segments/battery.p9k

--- a/test/segments/command_execution_time.spec
+++ b/test/segments/command_execution_time.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source segments/command_execution_time.p9k

--- a/test/segments/context.spec
+++ b/test/segments/context.spec
@@ -7,7 +7,9 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
-
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
+  
   # Test specific settings
   OLD_DEFAULT_USER=$DEFAULT_USER
   unset DEFAULT_USER

--- a/test/segments/custom.spec
+++ b/test/segments/custom.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
 
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme

--- a/test/segments/detect_virt.spec
+++ b/test/segments/detect_virt.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source segments/detect_virt.p9k

--- a/test/segments/dir.spec
+++ b/test/segments/dir.spec
@@ -12,6 +12,8 @@ function setUpOnce() {
 function setUp() {
   export TERM="xterm-256color"
   P9K_HOME="${PWD}"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source segments/dir.p9k
@@ -240,9 +242,6 @@ function testTruncateWithFolderMarkerInHome() {
   local BASEFOLDER=/tmp/powerlevel9k-test
   local SAVED_HOME=$HOME
   HOME=$BASEFOLDER
-
-  # Load Powerlevel9k
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
 
   local FOLDER=$BASEFOLDER/1/12/123/1234/12345/123456/1234567
   mkdir -p $FOLDER

--- a/test/segments/disk_usage.spec
+++ b/test/segments/disk_usage.spec
@@ -11,6 +11,10 @@ function setUp() {
   # Test specific
   P9K_HOME=$(pwd)
   FOLDER=/tmp/powerlevel9k-test
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
+  source "${P9K_HOME}/powerlevel9k.zsh-theme"
+  source "${P9K_HOME}/segments/disk_usage.p9k"
   mkdir -p $FOLDER
   cd $FOLDER
 }
@@ -37,9 +41,6 @@ function testDiskUsageSegmentWhenDiskIsAlmostFull() {
 /dev/disk1     487219288 471466944  15496344  97% /"
   }
 
-  # Load Powerlevel9k
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
-
   assertEquals "%K{001} %F{015}hdd  %f%F{015}97%% %k%F{001}%f " "$(__p9k_build_left_prompt)"
 
   unfunction df
@@ -53,9 +54,6 @@ function testDiskUsageSegmentWhenDiskIsVeryFull() {
 /dev/disk1     487219288 471466944  15496344  94% /"
   }
 
-  # Load Powerlevel9k
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
-
   assertEquals "%K{003} %F{000}hdd  %f%F{000}94%% %k%F{003}%f " "$(__p9k_build_left_prompt)"
 
   unfunction df
@@ -68,9 +66,6 @@ function testDiskUsageSegmentWhenDiskIsQuiteEmpty() {
       echo "Filesystem     1K-blocks      Used Available Use% Mounted on
 /dev/disk1     487219288 471466944  15496344  4% /"
   }
-
-  # Load Powerlevel9k
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
 
   assertEquals "%K{000} %F{046}hdd  %f%F{046}4%% %k%F{000}%f " "$(__p9k_build_left_prompt)"
 
@@ -102,9 +97,6 @@ function testDiskUsageSegmentWarningLevelCouldBeAdjusted() {
 /dev/disk1     487219288 471466944  15496344  11% /"
   }
 
-  # Load Powerlevel9k
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
-
   assertEquals "%K{003} %F{000}hdd  %f%F{000}11%% %k%F{003}%f " "$(__p9k_build_left_prompt)"
 
   unfunction df
@@ -119,9 +111,6 @@ function testDiskUsageSegmentCriticalLevelCouldBeAdjusted() {
     echo "Filesystem     1K-blocks      Used Available Use% Mounted on
 /dev/disk1     487219288 471466944  15496344  11% /"
   }
-
-  # Load Powerlevel9k
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
 
   assertEquals "%K{001} %F{015}hdd  %f%F{015}11%% %k%F{001}%f " "$(__p9k_build_left_prompt)"
 

--- a/test/segments/go_version.spec
+++ b/test/segments/go_version.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source segments/go_version.p9k

--- a/test/segments/ip.spec
+++ b/test/segments/ip.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source segments/ip.p9k

--- a/test/segments/kubecontext.spec
+++ b/test/segments/kubecontext.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source segments/kubecontext.p9k

--- a/test/segments/laravel_version.spec
+++ b/test/segments/laravel_version.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 }

--- a/test/segments/load.spec
+++ b/test/segments/load.spec
@@ -9,6 +9,8 @@ function setUp() {
   export TERM="xterm-256color"
 
   P9K_HOME=$(pwd)
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
   source ${P9K_HOME}/segments/load.p9k

--- a/test/segments/node_version.spec
+++ b/test/segments/node_version.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source segments/node_version.p9k

--- a/test/segments/nodeenv.spec
+++ b/test/segments/nodeenv.spec
@@ -7,7 +7,9 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
-
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
+  
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source segments/nodeenv.p9k

--- a/test/segments/nvm.spec
+++ b/test/segments/nvm.spec
@@ -16,6 +16,8 @@ function setUp() {
   OLD_PATH=$PATH
   PATH=${FOLDER}/bin:$PATH
   cd $FOLDER
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
   source ${P9K_HOME}/segments/nvm.p9k

--- a/test/segments/php_version.spec
+++ b/test/segments/php_version.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source segments/php_version.p9k

--- a/test/segments/public_ip.spec
+++ b/test/segments/public_ip.spec
@@ -18,6 +18,8 @@ function setUp() {
   # interfere with the tests.
   P9K_PUBLIC_IP_FILE=$FOLDER/public_ip_file
 
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
   source ${P9K_HOME}/segments/public_ip.p9k

--- a/test/segments/ram.spec
+++ b/test/segments/ram.spec
@@ -15,6 +15,8 @@ function setUp() {
   mkdir -p "${FOLDER}"
   cd $FOLDER
 
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
   source ${P9K_HOME}/segments/ram.p9k

--- a/test/segments/rust_version.spec
+++ b/test/segments/rust_version.spec
@@ -14,6 +14,8 @@ function setUp() {
   PATH="${RUST_TEST_FOLDER}:${PATH}"
 
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source segments/rust_version.p9k

--- a/test/segments/ssh.spec
+++ b/test/segments/ssh.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 }

--- a/test/segments/stack_project.spec
+++ b/test/segments/stack_project.spec
@@ -10,6 +10,8 @@ function setUp() {
   # Backing up P9K_MODE and setting it to default
   BACKUP_P9K_MODE=$P9K_MODE
   P9K_MODE=default
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   # Load Stack project segment

--- a/test/segments/status.spec
+++ b/test/segments/status.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source segments/status.p9k

--- a/test/segments/swap.spec
+++ b/test/segments/swap.spec
@@ -7,11 +7,17 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
 
   P9K_HOME=$(pwd)
   ### Test specific
   # Create default folder and git init it.
   FOLDER=/tmp/powerlevel9k-test/swap-test
+
+  source "${P9K_HOME}/powerlevel9k.zsh-theme"
+  source "${P9K_HOME}/segments/swap.p9k"
+
   mkdir -p "${FOLDER}"
   cd $FOLDER
 }
@@ -32,8 +38,6 @@ function testSwapSegmentWorksOnOsx() {
     echo "vm.swapusage: total = 3072,00M  used = 1620,50M  free = 1451,50M  (encrypted)"
   }
 
-  # Load Powerlevel9k
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
   local __P9K_OS="OSX" # Fake OSX
 
   assertEquals "%K{003} %F{000}SWP %f%F{000}1.58G " "$(prompt_swap left 1 false ${FOLDER})"
@@ -48,8 +52,6 @@ function testSwapSegmentWorksOnLinux() {
   echo "SwapTotal: 1000000" > proc/meminfo
   echo "SwapFree: 1000" >> proc/meminfo
 
-  # Load Powerlevel9k
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
   local __P9K_OS="Linux" # Fake Linux
 
   assertEquals "%K{003} %F{000}SWP %f%F{000}0.95G " "$(prompt_swap left 1 false ${FOLDER})"

--- a/test/segments/swift_version.spec
+++ b/test/segments/swift_version.spec
@@ -15,6 +15,8 @@ function setUp() {
   mkdir -p "${FOLDER}"
   cd $FOLDER
 
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
   source ${P9K_HOME}/segments/swift_version.p9k

--- a/test/segments/symfony_version.spec
+++ b/test/segments/symfony_version.spec
@@ -15,6 +15,8 @@ function setUp() {
   mkdir -p "${FOLDER}"
   cd $FOLDER
 
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
   source ${P9K_HOME}/segments/symfony2_version.p9k

--- a/test/segments/todo.spec
+++ b/test/segments/todo.spec
@@ -18,6 +18,8 @@ function setUp() {
   PATH=${FOLDER}/bin:$PATH
   cd $FOLDER
 
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
   source ${P9K_HOME}/segments/todo.p9k

--- a/test/segments/vagrant.spec
+++ b/test/segments/vagrant.spec
@@ -8,6 +8,8 @@ SHUNIT_PARENT=$0
 function setUp() {
   export TERM="xterm-256color"
   __P9K_HOME="${PWD}"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
   source segments/vagrant.p9k

--- a/test/segments/vcs_git.spec
+++ b/test/segments/vcs_git.spec
@@ -7,8 +7,12 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
 
   P9K_HOME=$(pwd)
+  source "${P9K_HOME}/powerlevel9k.zsh-theme"
+
   ### Test specific
   # Create default folder and git init it.
   FOLDER=/tmp/powerlevel9k-test/vcs-test
@@ -73,7 +77,7 @@ function testColorOverridingForCleanStateWorks() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_CLEAN_FOREGROUND='cyan'
   local P9K_VCS_CLEAN_BACKGROUND='white'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   assertEquals "%K{015} %F{006} master %k%F{015}%f " "$(__p9k_build_left_prompt)"
 }
@@ -83,7 +87,7 @@ function testColorOverridingForModifiedStateWorks() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_MODIFIED_FOREGROUND='red'
   local P9K_VCS_MODIFIED_BACKGROUND='yellow'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   touch testfile
   git add testfile
@@ -98,7 +102,7 @@ function testColorOverridingForUntrackedStateWorks() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_UNTRACKED_FOREGROUND='cyan'
   local P9K_VCS_UNTRACKED_BACKGROUND='yellow'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   touch testfile
 
@@ -108,7 +112,7 @@ function testColorOverridingForUntrackedStateWorks() {
 function testGitIconWorks() {
   local P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_GIT_ICON='Git-icon'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   assertEquals "%K{002} %F{000}Git-icon %f%F{000} master %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
@@ -117,7 +121,7 @@ function testGitlabIconWorks() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_GIT_GITLAB_ICON='GL-icon'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   # Add a GitLab project as remote origin. This is
   # sufficient to show the GitLab-specific icon.
@@ -130,7 +134,7 @@ function testBitbucketIconWorks() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_GIT_BITBUCKET_ICON='BB-icon'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   # Add a BitBucket project as remote origin. This is
   # sufficient to show the BitBucket-specific icon.
@@ -143,7 +147,7 @@ function testGitHubIconWorks() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_GIT_GITHUB_ICON='GH-icon'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   # Add a GitHub project as remote origin. This is
   # sufficient to show the GitHub-specific icon.
@@ -155,7 +159,7 @@ function testGitHubIconWorks() {
 function testUntrackedFilesIconWorks() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   # Create untracked file
   touch "i-am-untracked.txt"
@@ -167,7 +171,7 @@ function testStagedFilesIconWorks() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_STAGED_ICON='+'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   # Create staged file
   touch "i-am-added.txt"
@@ -183,7 +187,7 @@ function testUnstagedFilesIconWorks() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_UNSTAGED_ICON='M'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   # Create unstaged (modified, but not added to index) file
   touch "i-am-modified.txt"
@@ -198,7 +202,7 @@ function testStashIconWorks() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_STASH_ICON='S'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   # Create modified file
   touch "i-am-modified.txt"
@@ -214,7 +218,7 @@ function testTagIconWorks() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_TAG_ICON='T'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   touch "file.txt"
   git add file.txt
@@ -228,7 +232,7 @@ function testTagIconInDetachedHeadState() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_TAG_ICON='T'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   touch "file.txt"
   git add file.txt
@@ -246,7 +250,7 @@ function testTagIconInDetachedHeadState() {
 function testActionHintWorks() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   touch "i-am-modified.txt"
   git add i-am-modified.txt
@@ -268,7 +272,7 @@ function testIncomingHintWorks() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_INCOMING_CHANGES_ICON='I'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   touch "i-am-modified.txt"
   git add i-am-modified.txt
@@ -288,7 +292,7 @@ function testOutgoingHintWorks() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_OUTGOING_CHANGES_ICON='O'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   touch "i-am-modified.txt"
   git add i-am-modified.txt
@@ -309,7 +313,7 @@ function testShorteningCommitHashWorks() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_SHOW_CHANGESET=true
   local P9K_VCS_CHANGESET_HASH_LENGTH='4'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   touch "file.txt"
   git add file.txt
@@ -327,7 +331,7 @@ function testShorteningCommitHashIsNotShownIfShowChangesetIsFalse() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_SHOW_CHANGESET=false
   local P9K_VCS_CHANGESET_HASH_LENGTH='4'
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   touch "file.txt"
   git add file.txt
@@ -345,7 +349,7 @@ function testBranchNameTruncatingShortenLength() {
   local P9K_VCS_SHORTEN_LENGTH=6
   local P9K_VCS_SHORTEN_MIN_LENGTH=3
   local P9K_VCS_SHORTEN_STRATEGY="truncate_from_right"
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   FOLDER=/tmp/powerlevel9k-test/vcs-test
   mkdir -p $FOLDER
@@ -368,7 +372,7 @@ function testBranchNameTruncatingMinLength() {
   local P9K_VCS_SHORTEN_LENGTH=3
   local P9K_VCS_SHORTEN_MIN_LENGTH=6
   local P9K_VCS_SHORTEN_STRATEGY="truncate_from_right"
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   FOLDER=/tmp/powerlevel9k-test/vcs-test
   mkdir -p $FOLDER
@@ -392,7 +396,7 @@ function testBranchNameTruncatingShortenStrategy() {
   local P9K_VCS_SHORTEN_LENGTH=3
   local P9K_VCS_SHORTEN_MIN_LENGTH=3
   local P9K_VCS_SHORTEN_STRATEGY="truncate_from_right"
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   FOLDER=/tmp/powerlevel9k-test/vcs-test
   mkdir -p $FOLDER
@@ -414,6 +418,7 @@ function testRemoteBranchNameIdenticalToTag() {
   # This tests the fix from #941
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   echo "test" > test.txt
   git add test.txt 1>/dev/null
@@ -440,6 +445,7 @@ function testAlwaysShowRemoteBranch() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH='true'
   local P9K_VCS_HIDE_TAGS='true'
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   echo "test" > test.txt
   git add . 1>/dev/null
@@ -460,6 +466,7 @@ function testGitDirClobber() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_GIT_ALWAYS_SHOW_REMOTE_BRANCH='true'
   local P9K_VCS_HIDE_TAGS='true'
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   echo "xxx" > xxx.txt
   git add . 1>/dev/null
@@ -497,6 +504,7 @@ function testDetectingUntrackedFilesInSubmodulesWork() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_SHOW_SUBMODULE_DIRTY="true"
   unset P9K_VCS_UNTRACKED_BACKGROUND
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   mkdir ../submodule
   cd ../submodule
@@ -516,8 +524,6 @@ function testDetectingUntrackedFilesInSubmodulesWork() {
   touch "i-am-untracked.txt"
   cd -
 
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
-
   assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
@@ -526,6 +532,7 @@ function testDetectinUntrackedFilesInMainRepoWithDirtySubmodulesWork() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_SHOW_SUBMODULE_DIRTY="true"
   unset P9K_VCS_UNTRACKED_BACKGROUND
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   mkdir ../submodule
   cd ../submodule
@@ -542,8 +549,6 @@ function testDetectinUntrackedFilesInMainRepoWithDirtySubmodulesWork() {
   # Create untracked file
   touch "i-am-untracked.txt"
 
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
-
   assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
@@ -552,6 +557,7 @@ function testDetectingUntrackedFilesInNestedSubmodulesWork() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_SHOW_SUBMODULE_DIRTY="true"
   unset P9K_VCS_UNTRACKED_BACKGROUND
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   local mainRepo="${PWD}"
 
@@ -585,8 +591,6 @@ function testDetectingUntrackedFilesInNestedSubmodulesWork() {
   touch "i-am-untracked.txt"
   cd -
 
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
-
   assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
@@ -595,6 +599,7 @@ function testDetectingUntrackedFilesInCleanSubdirectoryWorks() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_SHOW_SUBMODULE_DIRTY="true"
   unset P9K_VCS_UNTRACKED_BACKGROUND
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   mkdir clean-folder
   touch clean-folder/file.txt
@@ -608,14 +613,13 @@ function testDetectingUntrackedFilesInCleanSubdirectoryWorks() {
   touch dirty-folder/new-file.txt
   cd clean-folder
 
-  source ${P9K_HOME}/powerlevel9k.zsh-theme
-
   assertEquals "%K{002} %F{000}? %f%F{000} master ? %k%F{002}%f " "$(__p9k_build_left_prompt)"
 }
 
 function testBranchNameScriptingVulnerability() {
   local -a P9K_LEFT_PROMPT_ELEMENTS
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
+  source "${P9K_HOME}/segments/vcs.p9k"
   echo "#!/bin/sh\n\necho 'hacked'\n" > evil_script.sh
   chmod +x evil_script.sh
 
@@ -631,6 +635,7 @@ function testGitSubmoduleWorks() {
   P9K_LEFT_PROMPT_ELEMENTS=(vcs)
   local P9K_VCS_SHOW_SUBMODULE_DIRTY="true"
   unset P9K_VCS_UNTRACKED_BACKGROUND
+  source "${P9K_HOME}/segments/vcs.p9k"
 
   mkdir ../submodule
   cd ../submodule
@@ -645,8 +650,6 @@ function testGitSubmoduleWorks() {
   git commit -m "Add submodule" 1>/dev/null
 
   cd submodule
-
-  source "${P9K_HOME}/powerlevel9k.zsh-theme"
 
   local result="$(__p9k_build_left_prompt 2>&1)"
   [[ "$result" =~ ".*(is outside repository)+" ]] && return 1

--- a/test/segments/vcs_hg.spec
+++ b/test/segments/vcs_hg.spec
@@ -19,6 +19,8 @@ function setUp() {
 
   hg init 1>/dev/null
 
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source ${P9K_HOME}/powerlevel9k.zsh-theme
 }

--- a/test/segments/vi_mode.spec
+++ b/test/segments/vi_mode.spec
@@ -7,6 +7,8 @@ SHUNIT_PARENT=$0
 
 function setUp() {
   export TERM="xterm-256color"
+  local -a P9K_RIGHT_PROMPT_ELEMENTS
+  P9K_RIGHT_PROMPT_ELEMENTS=()
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 }


### PR DESCRIPTION
The `background_jobs` segment needs the `zsh/parameter` module. That is now autoloaded by this module.
Additionally, for better debugability such issues in future, I show the loaded ZSH modules in travis.

Travis is still running, but the first tests on linux are passing.